### PR TITLE
交換局に関する情報を一括で提供するツールとしての mantela.json

### DIFF
--- a/mantela.schema.json
+++ b/mantela.schema.json
@@ -43,6 +43,9 @@
         "sipPort": {
           "description": "交換局の SIP ポート名やポート番号を指定してください",
           "type": "string"
+        },
+        "note": {
+          "description": "交換局に関する追加の情報を任意形式で指定してください"
         }
       }
     },


### PR DESCRIPTION
交換局の相互接続のために、交換局の管理者は各種の情報をやりとりする必要がありますが、これを簡略化する手段としての mantela.json を実現できるよう、任意形式のフィールドを追加するか考えています。