### PR TITLE
Add geolocationCoordinates

### DIFF
--- a/0.1/aboutme.json
+++ b/0.1/aboutme.json
@@ -44,6 +44,49 @@
       "description": "交換局の SIP ポート名やポート番号を指定してください",
       "type": "string"
     },
+    "geolocationCoordinates": {
+      "description": "地球上に設置されている交換局の設置されている物理的な位置や高度について指定してください",
+      "type": "object",
+      "properties": {
+        "latitude": {
+          "description": "位置の緯度を十進数の角度で指定してください",
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90
+        },
+        "longitude": {
+          "description": "位置の経度を十進数の角度で指定してください",
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180
+        },
+        "altitude": {
+          "description": "位置の海抜高度をメートル単位で指定してください",
+          "type": [ "number", "null" ]
+        },
+        "accuracy": {
+          "description": "経緯度の精度をメートル単位で指定してください",
+          "type": "number",
+          "minimum": 0
+        },
+        "altitudeAccuracy": {
+          "description": "海抜高度の精度をメートル単位で指定してください",
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude"
+      ]
+    },
     "unavailable": {
       "description": "交換局が（一時的に）利用できないとき、true を指定してください",
       "type": "boolean"


### PR DESCRIPTION
地球上に設置されている電話局の物理的な位置を表明できます。

追加されたプロパティは JavaScript において地球上の位置、高度、および測位精度を表わすインタフェイス [`GeolocationCoordinates`](https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates) のもつプロパティのサブセットになっており、[Geolocation API](https://developer.mozilla.org/docs/Web/API/Geolocation_API) を用いて得られた値をそのまま利用できます。