### PR TITLE
Support extensions[].image

### DIFF
--- a/0.1/aboutme.json
+++ b/0.1/aboutme.json
@@ -90,6 +90,11 @@
     "unavailable": {
       "description": "交換局が（一時的に）利用できないとき、true を指定してください",
       "type": "boolean"
+    },
+    "image": {
+      "description": "交換局に関連する画像の URI を指定してください",
+      "type": "string",
+      "format": "uri"
     }
   },
   "required": [

--- a/0.1/extensions.json
+++ b/0.1/extensions.json
@@ -96,6 +96,11 @@
           "latitude",
           "longitude"
         ]
+      },
+      "image": {
+        "description": "端末に関連する画像の URI を指定してください",
+        "type": "string",
+        "format": "uri"
       }
     },
     "required": [


### PR DESCRIPTION
issue の assignee を平然と無視して申し訳ないです

このプロパティには接続されている端末に関連する画像の URI を指定します

ところで、aboutMe にも image があったら面白いと思いませんか？ 例えば、交換局のホストしているコンピュータの画像であったり、交換局のイメージアイコンを指定するような用途が考えられます。