### PR TITLE
Deprecate `sipUsername`, `sipPassword`, `sipServer`, and `sipPort` and use `sipURI`

### DIFF
--- a/0.1/aboutme.json
+++ b/0.1/aboutme.json
@@ -48,7 +48,7 @@
       "deprecated": true,
       "type": "string"
     },
-    "sipURI": {
+    "sipUri": {
       "description": "交換局の SIP あるいは SIPS の URI を指定してください（c.f.: RFC3261 §19.1）",
       "type": "array",
       "items": {

--- a/0.1/aboutme.json
+++ b/0.1/aboutme.json
@@ -29,20 +29,32 @@
       "pattern": "^[\\x21-\\x7E]+$"
     },
     "sipUsername": {
-      "description": "交換局の SIP ユーザ名を指定してください",
+      "description": "交換局の SIP ユーザ名を指定してください（非推奨; c.f.: sipURI）",
+      "deprecated": true,
       "type": "string"
     },
     "sipPassword": {
-      "description": "交換局の SIP パスワードを指定してください",
+      "description": "交換局の SIP パスワードを指定してください（非推奨; c.f.: sipURI）",
+      "deprecated": true,
       "type": "string"
     },
     "sipServer": {
-      "description": "交換局の SIP ホスト名や IP アドレスを指定してください",
+      "description": "交換局の SIP ホスト名や IP アドレスを指定してください（非推奨; c.f.: sipURI）",
+      "deprecated": true,
       "type": "string"
     },
     "sipPort": {
-      "description": "交換局の SIP ポート名やポート番号を指定してください",
+      "description": "交換局の SIP ポート名やポート番号を指定してください（非推奨; c.f.: sipURI）",
+      "deprecated": true,
       "type": "string"
+    },
+    "sipURI": {
+      "description": "交換局の SIP あるいは SIPS の URI を指定してください（c.f.: RFC3261 §19.1）",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
     },
     "geolocationCoordinates": {
       "description": "地球上に設置されている交換局の設置されている物理的な位置や高度について指定してください",


### PR DESCRIPTION
`sipUsername`、`sipPassword`、`sipServer`、及び `sipPort` を非推奨にし、 かわりに `sipURI` を利用します。これに指定される値は配列であり、その要素は RFC 3261 のセクション 19.1 で規定されている形式の文字列であることを期待されています。